### PR TITLE
Fixed typo in global_step number acquisition

### DIFF
--- a/main.py
+++ b/main.py
@@ -294,7 +294,7 @@ class Processor():
 
         if self.arg.weights:
             try:
-                self.global_step = int(arg.weights[:-3].split('-')[-1])
+                self.global_step = int(self.arg.weights[:-3].split('-')[-1])
             except:
                 print('Cannot parse global_step from model weights filename')
                 self.global_step = 0


### PR DESCRIPTION
Added **`self`** reference since it was missing.
The **`self`** reference was missing, so it was added. If **`self`** is not mentioned, an error will always occur.